### PR TITLE
Avoid using the ambiguous \h shorthand character

### DIFF
--- a/Syntaxes/Nu.tmLanguage
+++ b/Syntaxes/Nu.tmLanguage
@@ -50,7 +50,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(')(.|\\[nrfbaes]|\\[0-7]{3}|\\x\h{2}|\\u\h{4})(')</string>
+			<string>(')(.|\\[nrfbaes]|\\[0-7]{3}|\\x[0-9A-Fa-f]{2}|\\u[0-9A-Fa-f]{4})(')</string>
 			<key>name</key>
 			<string>constant.character.nu</string>
 		</dict>
@@ -779,7 +779,7 @@
 		<key>escaped_char</key>
 		<dict>
 			<key>match</key>
-			<string>\\([0-7]{3}|x\h{2}|u\h{4}|.)</string>
+			<string>\\([0-7]{3}|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}|.)</string>
 			<key>name</key>
 			<string>constant.character.escape.nu</string>
 		</dict>


### PR DESCRIPTION
Depending on the regular expression engine used, `\h` does not always
mean the same. With a PCRE engine, it matches white spaces, whereas,
with a Oniguruma engine, it matches hexademical digit characters.
TextMate uses an Oniguruma engine, but github.com relies on a PCRE
engine.